### PR TITLE
Improve Hugging Face integration

### DIFF
--- a/lit_gpt/model_cache.py
+++ b/lit_gpt/model_cache.py
@@ -1,6 +1,8 @@
 import math
 from typing import Any, List, Optional, Tuple
 
+from huggingface_hub import PyTorchModelHubMixin
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -166,7 +168,10 @@ class Hourglass(torch.nn.Module):
 
         return x
 
-class GPTCache(nn.Module):
+class GPTCache(nn.Module,
+               PyTorchModelHubMixin,
+               repo_id="https://github.com/zhaorw02/DeepMesh",
+               license="mit"):
     def __init__(self, config: Config) -> None:
         super().__init__()
         assert config.padded_vocab_size is not None


### PR DESCRIPTION
This PR improves the Hugging Face integration by:

* equiping the model with `from_pretrained` and `push_to_hub` capabilities
* use `safetensors` for weights serialization
* have download stats for your model.

This is all supported thanks to the [PyTorchModelHubMixin](https://huggingface.co/docs/hub/models-uploading#upload-a-pytorch-model-using-huggingfacehub) class. It works like so:

```python
from lit_gpt.model_cache import GPTCache

model = GPTCache(...)

# equip with weights
filepath = hf_hub_download(repo_id="zzzrw/DeepMesh", filename="pytorch_model.bin")
state_dict = torch.load(filepath, map_location="cpu")
model.load_state_dict(state_dict)

# push to the hub
model.push_to_hub("zzzrw/DeepMesh")

# now anyone can use it like so:
model = GPTCache.from_pretrained("zzzrw/DeepMesh")
```

Feel free to try it out!